### PR TITLE
Fixed a dependency and added a directory for the config

### DIFF
--- a/CloudKitty/api/Dockerfile
+++ b/CloudKitty/api/Dockerfile
@@ -1,13 +1,15 @@
 FROM python:3.7-slim-buster
 
-RUN  apt-get update \
+RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         apache2 \
         libapache2-mod-wsgi-py3 \
         gcc \
         python3-dev \
-    && pip install cloudkitty \
-    && mkdir /etc/cloudkitty \
+    && pip install cloudkitty PyMySQL \
+    && mkdir \
+        /etc/cloudkitty \
+        /etc/cloudkitty-config \
     && apt-get purge -y \
         gcc \
         python3-dev \

--- a/CloudKitty/processor/Dockerfile
+++ b/CloudKitty/processor/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-buster
 
-RUN pip install cloudkitty
+RUN pip install cloudkitty PyMySQL
 
 CMD [ "cloudkitty-processor" ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This repository contains the Dockerfiles for Objectif Libre's official images.
 
 ## CloudKitty
 
+If you wish to configure CloudKitty, the configuration files are located here :
+
+- `/etc/cloudkitty/metrics.yml`
+- `/etc/cloudkitty/cloudkitty.conf`
+
+Please, refer to the [documentation of cloudkitty](https://docs.openstack.org/cloudkitty/latest/admin/configuration/configuration.html) if you don't know how to use theses files.
+
 ### api
 
 Contains the Dockerfile for CloudKitty's API and its dependencies.


### PR DESCRIPTION
In order to have compatibility between CloudKitty
and Kubernetes, we need to have a repository
for processing the ConfigMap.
There where a problem with PyMySQL which
where missing.
Updated the readme to explain where to put the config